### PR TITLE
feat: add BingSiteAuth.xml for user authentication

### DIFF
--- a/src/BingSiteAuth.xml
+++ b/src/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>6C36FE3A9F6C18D88B2DF27F4081AB9E</user>
+</users>


### PR DESCRIPTION
This PR adds the BingSiteAuth.xml file to the project root to verify site ownership with Bing Webmaster Tools. This step is required to enable indexing and monitor search visibility on Bing (used by Microsoft Edge and other Microsoft services).

Changes Included:
- Added BingSiteAuth.xml at the project root
- No application logic or UI changes